### PR TITLE
 #553 Fix issue with text box height

### DIFF
--- a/unity/Assets/Scripts/Quest/DialogWindow.cs
+++ b/unity/Assets/Scripts/Quest/DialogWindow.cs
@@ -64,13 +64,12 @@ public class DialogWindow {
     public void CreateWindow()
     {
         // Draw text
-        float offset = UIElement.GetStringHeight(text, 28);
+        UIElement ui = new UIElement();
+        float offset = ui.GetStringHeight(text, 28);
         if (offset < 4)
         {
             offset = 4;
         }
-
-        UIElement ui = new UIElement();
         ui.SetLocation(UIScaler.GetHCenter(-14f), 0.5f, 28, offset);
         ui.SetText(text);
         new UIElementBorder(ui);
@@ -85,7 +84,7 @@ public class DialogWindow {
         List<DialogWindow.EventButton> buttons = eventData.GetButtons();
         foreach (EventButton eb in buttons)
         {
-            float length = UIElement.GetStringWidth(eb.GetLabel().Translate(), UIScaler.GetMediumFont());
+            float length = ui.GetStringWidth(eb.GetLabel().Translate(), UIScaler.GetMediumFont());
             if (length > buttonWidth)
             {
                 buttonWidth = length;
@@ -123,13 +122,12 @@ public class DialogWindow {
     public void CreateQuotaWindow()
     {
         // Draw text
-        float offset = UIElement.GetStringHeight(text, 28);
+        UIElement ui = new UIElement();
+        float offset = ui.GetStringHeight(text, 28);
         if (offset < 4)
         {
             offset = 4;
         }
-
-        UIElement ui = new UIElement();
         ui.SetLocation(UIScaler.GetHCenter(-14f), 0.5f, 28, offset);
         ui.SetText(text);
         new UIElementBorder(ui);

--- a/unity/Assets/Scripts/Quest/LogWindow.cs
+++ b/unity/Assets/Scripts/Quest/LogWindow.cs
@@ -51,7 +51,7 @@ public class LogWindow
             string entry = e.GetEntry(developerToggle).Trim('\n');
             if (entry.Length == 0) continue;
             ui = new UIElement(scrollArea.GetScrollTransform());
-            float height = UIElement.GetStringHeight(entry, textWidth);
+            float height = ui.GetStringHeight(entry, textWidth);
             ui.SetLocation(0, offset, textWidth, height);
             ui.SetText(entry, Color.black);
             ui.SetBGColor(Color.white);

--- a/unity/Assets/Scripts/UI/Screens/QuestDetailsScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/QuestDetailsScreen.cs
@@ -32,17 +32,17 @@ namespace Assets.Scripts.UI.Screens
             }
 
             // Draw Description
-            float height = UIElement.GetStringHeight(q.description, 30);
-            if (height > 25) height = 25;
             ui = new UIElement();
+            float height = ui.GetStringHeight(q.description, 30);
+            if (height > 25) height = 25;
             ui.SetLocation(UIScaler.GetHCenter(-7), 15 - (height / 2), 30, height);
             ui.SetText(q.description);
             new UIElementBorder(ui);
 
             // Draw authors
-            height = UIElement.GetStringHeight(q.authors, 14);
-            if (height > 25) height = 25;
             ui = new UIElement();
+            height = ui.GetStringHeight(q.authors, 14);
+            if (height > 25) height = 25;
             ui.SetLocation(UIScaler.GetHCenter(-23), 18.5f - (height / 2), 14, height);
             ui.SetText(q.authors);
             new UIElementBorder(ui);

--- a/unity/Assets/Scripts/UI/UIElement.cs
+++ b/unity/Assets/Scripts/UI/UIElement.cs
@@ -21,8 +21,8 @@ namespace Assets.Scripts.UI
         protected float textPadding = textPaddingDefault;
 
         // Used for calculating text size
-        protected static GameObject textWidthObj;
-        protected static GameObject textHeightObj;
+        protected GameObject textWidthObj;
+        protected GameObject textHeightObj;
 
         protected UnityEngine.Events.UnityAction buttonCall;
 
@@ -301,7 +301,7 @@ namespace Assets.Scripts.UI
         /// <param name="content">Text to translate.</param>
         /// <returns>
         /// The size of the text in UIScaler units.</returns>
-        public static float GetStringWidth(StringKey content)
+        public float GetStringWidth(StringKey content)
         {
             return GetStringWidth(content.Translate());
         }
@@ -311,7 +311,7 @@ namespace Assets.Scripts.UI
         /// <param name="content">Text to measure.</param>
         /// <returns>
         /// The size of the text in UIScaler units.</returns>
-        public static float GetStringWidth(string content)
+        public float GetStringWidth(string content)
         {
             return GetStringWidth(content, UIScaler.GetSmallFont());
         }
@@ -322,7 +322,7 @@ namespace Assets.Scripts.UI
         /// <param name="fontSize">Size of font.</param>
         /// <returns>
         /// The size of the text in UIScaler units.</returns>
-        public static float GetStringWidth(string content, int fontSize)
+        public float GetStringWidth(string content, int fontSize)
         {
             if (textWidthObj == null)
             {
@@ -344,7 +344,7 @@ namespace Assets.Scripts.UI
         /// <param name="width">Width of the text box in UIScaler units.</param>
         /// <returns>
         /// The required text box height in UIScaler units.</returns>
-        public static float GetStringHeight(StringKey content, float width)
+        public float GetStringHeight(StringKey content, float width)
         {
             return GetStringHeight(content.Translate(), width);
         }
@@ -355,7 +355,7 @@ namespace Assets.Scripts.UI
         /// <param name="width">Width of the text box in UIScaler units.</param>
         /// <returns>
         /// The required text box height in UIScaler units.</returns>
-        public static float GetStringHeight(string content, float width)
+        public float GetStringHeight(string content, float width)
         {
             if (textHeightObj == null)
             {


### PR DESCRIPTION
GameObject needs to be new for Unity to provide a proper height.
Apply to width too just in case.
