### PR TITLE
#842 #809 New load / save system

### DIFF
--- a/unity/Assets/Scripts/Content/ContentData.cs
+++ b/unity/Assets/Scripts/Content/ContentData.cs
@@ -56,6 +56,15 @@ public class ContentData {
         return Game.AppData() + "/" + Game.Get().gameType.TypeName() + "/import";
     }
 
+    /// <summary>
+    /// Get download directory without trailing '/'
+    /// </summary>
+    /// <returns>location to save / load packages</returns>
+    public static string DownloadPath()
+    {
+        return Game.AppData() + Path.DirectorySeparatorChar + "Download";
+    }
+
     public static string TempPath
     {
         get

--- a/unity/Assets/Scripts/Content/QuestData.cs
+++ b/unity/Assets/Scripts/Content/QuestData.cs
@@ -22,6 +22,9 @@ public class QuestData
     // Location of the quest.ini file
     public string questPath = "";
 
+    // Original package filename, this is required for quest with multiple quest
+    public string package_filename = "";
+
     // Dictionary of items to rename on reading
     public Dictionary<string, string> rename;
 
@@ -41,6 +44,14 @@ public class QuestData
     public QuestData(string path)
     {
         questPath = path;
+        LoadQuestData();
+    }
+    
+    // Read all data files and populate components for quest and save original package name (required for quest loaded from inside a quest)
+    public QuestData(string path, string package_filename)
+    {
+        questPath = path;
+        this.package_filename = package_filename;
         LoadQuestData();
     }
 
@@ -117,6 +128,18 @@ public class QuestData
             qstDict.AddDataFromFile(file);
         }
         LocalizationRead.AddDictionary("qst", qstDict);
+
+        // if package filename is already set, it means we are already in another quest: do not overwrite with data from sub-quest
+        if (package_filename == "") {
+            if (questIniData.Get("Package", "filename") != "")
+            {
+                package_filename = questIniData.Get("Package", "filename");
+            }
+            else
+            {
+                ValkyrieDebug.Log("Quest is not an archive");
+            }
+        }
 
         foreach (string f in iniFiles)
         {
@@ -1926,6 +1949,13 @@ public class QuestData
         {
             path = pathIn;
             Dictionary<string, string> iniData = IniRead.ReadFromIni(path + "/quest.ini", "Quest");
+
+            // do not parse the content of a quest from another game type
+            if (iniData.ContainsKey("type") && iniData["type"] != Game.Get().gameType.TypeName())
+            {
+                valid = false;
+                return;
+            }
 
             //Read the localization data
             Dictionary<string, string> localizationData = IniRead.ReadFromIni(path + "/quest.ini", "QuestText");

--- a/unity/Assets/Scripts/Content/QuestDownload.cs
+++ b/unity/Assets/Scripts/Content/QuestDownload.cs
@@ -337,12 +337,12 @@ public class QuestDownload : MonoBehaviour
     }
 
     /// <summary>
-    /// Get save directory without trailing '/'
+    /// Get download directory without trailing '/'
     /// </summary>
-    /// <returns>localtion to save packages</returns>
+    /// <returns>location to save packages</returns>
     public string saveLocation()
     {
-        return Game.AppData() + "/Download";
+        return ContentData.DownloadPath();
     }
 
     /// <summary>

--- a/unity/Assets/Scripts/Game.cs
+++ b/unity/Assets/Scripts/Game.cs
@@ -207,6 +207,9 @@ public class Game : MonoBehaviour {
     // This is called when a quest is selected
     public void StartQuest(QuestData.Quest q)
     {
+        // extract the full package
+        QuestLoader.ExtractFullPackage(ContentData.DownloadPath()+ Path.DirectorySeparatorChar + Path.GetFileName(q.path) );
+
         // Fetch all of the quest data and initialise the quest
         quest = new Quest(q);
 

--- a/unity/Assets/Scripts/Quest/EventManager.cs
+++ b/unity/Assets/Scripts/Quest/EventManager.cs
@@ -111,12 +111,13 @@ public class EventManager
         // Check if the event doesn't exists - quest fault
         if (!events.ContainsKey(name))
         {
-            if (File.Exists(Path.GetDirectoryName(game.quest.qd.questPath) + "/" + name))
+            if (File.Exists(game.quest.originalPath + "/" + name))
             {
                 events.Add(name, new StartQuestEvent(name));
             }
             else
             {
+                ValkyrieDebug.Log("Warning: Missing event called: " + name);
                 game.quest.log.Add(new Quest.LogEntry("Warning: Missing event called: " + name, true));
                 return;
             }
@@ -395,13 +396,14 @@ public class EventManager
             // Check if the event doesn't exists - quest fault
             if (!events.ContainsKey(s))
             {
-                if (File.Exists(Path.GetDirectoryName(game.quest.qd.questPath) + "/" + s))
+                if (File.Exists(game.quest.originalPath + "/" + s))
                 {
                     events.Add(s, new StartQuestEvent(s));
                     enabledEvents.Add(s);
                 }
                 else
                 {
+                    ValkyrieDebug.Log("Warning: Missing event called: " + s);
                     game.quest.log.Add(new Quest.LogEntry("Warning: Missing event called: " + s, true));
                 }
             }
@@ -655,13 +657,14 @@ public class EventManager
                     // Check if the event doesn't exists - quest fault
                     if (!game.quest.eManager.events.ContainsKey(s))
                     {
-                        if (File.Exists(game.quest.questPath + "/" + s))
+                        if (File.Exists(game.quest.originalPath + "/" + s))
                         {
                             game.quest.eManager.events.Add(s, new StartQuestEvent(s));
                             return true;
                         }
                         else
                         {
+                            ValkyrieDebug.Log("Warning: Missing event called: " + s);
                             game.quest.log.Add(new Quest.LogEntry("Warning: Missing event called: " + s, true));
                             return false;
                         }

--- a/unity/Assets/Scripts/Quest/Quest.cs
+++ b/unity/Assets/Scripts/Quest/Quest.cs
@@ -14,9 +14,14 @@ public class Quest
     public QuestData qd;
 
     /// <summary>
-    /// Original Quest Path
+    /// Current Quest Path
     /// </summary>
     public string questPath = "";
+
+    /// <summary>
+    /// Original Quest Path
+    /// </summary>
+    public string originalPath = "";
 
     /// <summary>
     /// components on the board (tiles, tokens, doors)
@@ -97,6 +102,7 @@ public class Quest
         // Static data from the quest file
         qd = new QuestData(q);
         questPath = Path.GetDirectoryName(qd.questPath);
+        originalPath = Path.GetDirectoryName(qd.questPath);
 
         // Initialise data
         boardItems = new Dictionary<string, BoardComponent>();
@@ -535,11 +541,12 @@ public class Quest
         game.cc.maxLimit = false;
 
         // Set static quest data
-        qd = new QuestData(questPath + "/" + path);
+        qd = new QuestData(originalPath + "/" + path, qd.package_filename);
+        // set questPath but do not set original path, as we are loading from within a quest here.
         questPath = Path.GetDirectoryName(qd.questPath);
 
-        // Extract packages in case needed
-        QuestLoader.ExtractPackages(Game.AppData());
+        // Cannot load a quest from another archive (we don't know want to extract all available archives everytime here)
+        // QuestLoader.ExtractPackages(Game.AppData());
 
         vars.TrimQuest();
 
@@ -730,9 +737,14 @@ public class Quest
         }
 
         // Set static quest data
-        qd = new QuestData(saveData.Get("Quest", "path"));
+        string pk_path = saveData.Get("Quest", "packagepath");
+        if (pk_path != "")
+            qd = new QuestData(saveData.Get("Quest", "path"), pk_path);
+        else
+            qd = new QuestData(saveData.Get("Quest", "path"));
 
-        questPath = saveData.Get("Quest", "originalpath");
+        originalPath = saveData.Get("Quest", "originalpath");
+        questPath = saveData.Get("Quest", "path");
 
         monsterSelect = saveData.Get("SelectMonster");
         if (monsterSelect == null)
@@ -1109,7 +1121,15 @@ public class Quest
         r += "valkyrie=" + game.version + nl;
 
         r += "path=" + qd.questPath + nl;
-        r += "originalpath=" + questPath + nl;
+        r += "originalpath=" + originalPath + nl;
+        r += "questname=" + qd.quest.name.Translate() + nl;
+
+        // we keep package filename to be able to extract the package when loading from a savegame
+        if (qd.package_filename != "")
+        {
+            r += "packagepath=" + qd.package_filename + nl;
+        }
+
         if (phase == MoMPhase.horror)
         {
             r += "horror=true" + nl;


### PR DESCRIPTION
- Savegames do not contain the full quest anymore (performance improvement)
- When listing quests, just extract necessary files from packages (performance improvement)
- When listing quests, search for content in the editor of game type directory and in Download directory
- Only when starting quest, extract the full archive
- #842: loading from a savegame will extract the full archive
- #809: external quest path are now based on root quest (you should not use ../ anymore)
- Do not extract all quests packages available when loading a quest from a quest : a quest can be started from another quest only if they all are in the same quest archive

Limitations :
- Updating a quest that is saved may break your savegame (todo: add warning)
- Deleting a quest that is saved *will* break your savegame (todo: add warning)